### PR TITLE
Fix handling of netlink sockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
-.idea/
 /target/
 **/*.rs.bk
+
+# Common editor/IDE files
+.idea/
+*.iml
+*.swp
+*.swo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ name = "ptools"
 version = "0.1.0"
 dependencies = [
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ path = "src/bin/ptree.rs"
 [[bin]]
 name = "epoll_example"
 path = "src/bin/testing/epoll.rs"
+[[bin]]
+name = "netlink_example"
+path = "src/bin/testing/netlink.rs"
 
 [profile.release]
 lto = true
@@ -34,6 +37,7 @@ panic = "abort" # Save size. We don't need unwinding anyway.
 [dependencies]
 getopts = "0.2.15"
 nix = "0.12.0"
+libc = "0.2.48"
 
 [package.metadata.deb]
 assets = [

--- a/src/bin/testing/netlink.rs
+++ b/src/bin/testing/netlink.rs
@@ -1,0 +1,47 @@
+//
+//   Copyright 2019 Delphix
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+use nix::sys::socket::{socket, AddressFamily, SockAddr, SockType, SockFlag, bind};
+use nix::errno::Errno;
+
+use std::fs::File;
+use std::os::raw::c_int;
+
+extern crate nix;
+
+const NETLINK_ROUTE: c_int = 0;
+
+fn main() {
+    // Use libc crate directly instead of nix because nix's 'socket' method doesn't have ability to
+    // specify netlink socket protocol.
+    let fd = unsafe {
+        libc::socket(AddressFamily::Netlink as c_int,
+        SockType::Datagram as c_int,
+        NETLINK_ROUTE)
+    };
+
+    let fd = Errno::result(fd).unwrap();
+
+    bind(fd, &SockAddr::new_netlink(0, 0));
+
+    // Signal parent process (the test process) that this process is ready to be observed by the
+    // ptool being tested.
+    File::create("/tmp/ptools-test-ready").unwrap();
+
+    // Wait for the parent finish running the ptool and then kill us.
+    loop {}
+}
+

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,70 @@
+//
+//   Copyright 2018, 2019 Delphix
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+use std::path::{Path, PathBuf};
+use std::fs;
+use std::io;
+use std::process::{Command, Stdio};
+
+// Find an executable produced by the Cargo build
+fn find_exec(name: &str) -> PathBuf {
+
+    // Find the path where Cargo has placed the executables by looking at this test process's
+    // executable, which was also built by Cargo.
+    let this_exec = std::env::current_exe().unwrap();
+    let exec_dir = this_exec.parent().unwrap().parent().unwrap();
+
+    exec_dir.join(name)
+}
+
+// Run a ptool against a sample process and return the stdout of the ptool
+pub fn run_ptool(tool: &str, test_proc: &str) -> String {
+
+    let signal_file = Path::new("/tmp/ptools-test-ready");
+    if let Err(e) = fs::remove_file(signal_file) {
+        if e.kind() != io::ErrorKind::NotFound {
+            panic!("Failed to remove {:?}: {:?}", signal_file, e.kind())
+        }
+    }
+
+    let mut examined_proc = Command::new(find_exec(test_proc))
+        .stdin(Stdio::null())
+        .stderr(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .spawn()
+        .unwrap();
+
+    // Wait for process-to-be-examined to be ready
+    while !signal_file.exists() {
+        if let Some(status) = examined_proc.try_wait().unwrap() {
+            panic!("Child exited too soon with status {}", status)
+        }
+    }
+
+    let pfiles_output = Command::new(find_exec(tool))
+        .arg(examined_proc.id().to_string())
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&pfiles_output.stderr);
+    let stdout = String::from_utf8_lossy(&pfiles_output.stdout);
+    assert_eq!(stderr, "");
+
+    examined_proc.kill().unwrap();
+
+    stdout.into_owned()
+}
+

--- a/tests/epoll_test.rs
+++ b/tests/epoll_test.rs
@@ -1,56 +1,27 @@
-use std::path::{Path, PathBuf};
-use std::fs;
-use std::io;
-use std::process::{Command, Stdio};
+//
+//   Copyright 2018, 2019 Delphix
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
 
-// Find an executable produced by the Cargo build
-fn find_exec(name: &str) -> PathBuf {
-
-    // Find the path where Cargo has placed the executables by looking at this test process's
-    // executable, which was also built by Cargo.
-    let this_exec = std::env::current_exe().unwrap();
-    let exec_dir = this_exec.parent().unwrap().parent().unwrap();
-
-    exec_dir.join(name)
-}
+mod common;
 
 #[test]
-fn test_epoll() {
-
-    let signal_file = Path::new("/tmp/ptools-test-ready");
-    if let Err(e) = fs::remove_file(signal_file) {
-        if e.kind() != io::ErrorKind::NotFound {
-            panic!("Failed to remove {:?}: {:?}", signal_file, e.kind())
-        }
-    }
-
-    let mut example_proc = Command::new(find_exec("epoll_example"))
-        .stdin(Stdio::null())
-        .stderr(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .spawn()
-        .unwrap();
-
-    // Wait for example process to be ready
-    while !signal_file.exists() {
-       if let Some(status) = example_proc.try_wait().unwrap() {
-           panic!("Child exited too soon with status {}", status)
-       }
-    }
-
-    let pfiles_output = Command::new(find_exec("pfiles"))
-        .arg(example_proc.id().to_string())
-        .stdin(Stdio::null())
-        .output()
-        .unwrap();
-    let stderr = String::from_utf8_lossy(&pfiles_output.stderr);
-    let stdout = String::from_utf8_lossy(&pfiles_output.stdout);
-    assert_eq!(stderr, "");
+fn epoll_basic() {
+    let stdout = common::run_ptool("pfiles", "epoll_example");
 
     let pattern = "5: anon_inode(epoll)";
     if !stdout.contains(pattern) {
         panic!("String '{}' not found in command output:\n\n{}\n\n", pattern, stdout);
     }
-
-    example_proc.kill().unwrap();
 }

--- a/tests/netlink_test.rs
+++ b/tests/netlink_test.rs
@@ -1,0 +1,46 @@
+//
+//   Copyright 2019 Delphix
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+mod common;
+
+#[test]
+fn netlink_basic() {
+    let stdout = common::run_ptool("pfiles", "netlink_example");
+    let lines = stdout.lines().collect::<Vec<&str>>();
+
+    //
+    // We expect something along the lines of
+    // ...
+    //     3: S_IFSOCK mode:777 dev:0,9 ino:725134 uid:65433 gid:50 size:0
+    //        O_RDWR
+    //          SOCK_DGRAM
+    //          sockname: AF_NETLINK
+    //
+    let pattern = "3: S_IFSOCK";
+    let split_lines = lines
+        .split(|l| l.trim().starts_with(pattern))
+        .collect::<Vec<_>>();
+
+    if split_lines.len() != 2 {
+        panic!("String '{}' not found in command output:\n\n{}\n\n", pattern, stdout);
+    }
+    let fd_info = split_lines[1];
+
+    let pattern = "sockname: AF_NETLINK";
+    if fd_info[2].trim() != pattern {
+        panic!("String '{}' not found in command output:\n\n{}\n\n", pattern, fd_info.join("\n"));
+    }
+}


### PR DESCRIPTION
Currently, `pfiles` doesn't read any information about netlink sockets from procfs, and when it encounters a netlink socket, it panics:

```
$ sudo pfiles 1
...
    9: S_IFSOCK mode:777 dev:0,9 ino:12636 uid:0 gid:0 size:0
       O_RDWR|O_CLOEXEC|O_NDELAY | O_NONBLOCK
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/libcore/option.rs:347:21
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
Aborted
...
```

This set of commits
 - Makes `pfiles` more robust to missing socket information by printing an error and continuing instead of panicking.
 - Reads `/proc/[pid]/net/netlink` so that it can figure out which sockets are netlink sockets.
 - Refactors the test code to make it easier to new tests.
 - Adds a test for running `pfiles` against a process using a netlink socket.

New output
```
...
    9: S_IFSOCK mode:777 dev:0,9 ino:12636 uid:0 gid:0 size:0
       O_RDWR|O_CLOEXEC|O_NDELAY | O_NONBLOCK
         SOCK_DGRAM
         sockname: AF_NETLINK
...
```