### PR TITLE
Improve error handling in print_files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ name = "netlink_example"
 path = "src/bin/testing/netlink.rs"
 
 [profile.release]
+debug = true
 lto = true
 panic = "abort" # Save size. We don't need unwinding anyway.
 # TODO is there any way to remove the ability to display backtraces? This would


### PR DESCRIPTION
`ptools` still contains some amount of hackathon-quality error handling. In particular, `pfiles` can panic if a file descriptor in the target process is closed while `pfiles` is iterating over the entries in `/proc/[pid]/fd/`. This modifies `pfiles` to instead print a message to stderr and continue iterating over the file descriptors.
```
delphix@jg-trunk:~/ptools$ pfiles 17902
17902:  ./test
    0: S_IFCHR mode:620 dev:0,23 ino:4 uid:65433 gid:5 rdev:136,1
       O_RDWR
       /dev/pts/1
    1: S_IFCHR mode:620 dev:0,23 ino:4 uid:65433 gid:5 rdev:136,1
       O_RDWR
       /dev/pts/1
    2: S_IFCHR mode:620 dev:0,23 ino:4 uid:65433 gid:5 rdev:136,1
       O_RDWR
       /dev/pts/1
failed to stat /proc/17902/fd/3: ENOENT: No such file or directory
    4: S_IFSOCK mode:777 dev:0,9 ino:27996 uid:0 gid:0 size:0
       O_RDWR
         SOCK_STREAM
         sockname: AF_INET 0.0.0.0  port: 5005
    ...
```

I'll follow up with additional PRs to clean up more of the error handling, but this should prevent the issue where pfiles occasionally creates a coredump while a support bundle is being generated.

This also modifies `Cargo.toml` to ensure that full debug info is generated when we do a release build, since I notice that some debug info was missing while I was investigating this issue.

Closes #9 

cc @palashgandhi