### PR TITLE
Sync 6.0/stage with master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,11 @@
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ name = "netlink_example"
 path = "src/bin/testing/netlink.rs"
 
 [profile.release]
+debug = true
 lto = true
 panic = "abort" # Save size. We don't need unwinding anyway.
 # TODO is there any way to remove the ability to display backtraces? This would

--- a/src/bin/testing/netlink.rs
+++ b/src/bin/testing/netlink.rs
@@ -14,7 +14,7 @@
 //   limitations under the License.
 //
 
-use nix::sys::socket::{socket, AddressFamily, SockAddr, SockType, SockFlag, bind};
+use nix::sys::socket::{AddressFamily, SockAddr, SockType, bind};
 use nix::errno::Errno;
 
 use std::fs::File;
@@ -35,7 +35,7 @@ fn main() {
 
     let fd = Errno::result(fd).unwrap();
 
-    bind(fd, &SockAddr::new_netlink(0, 0));
+    bind(fd, &SockAddr::new_netlink(0, 0)).unwrap();
 
     // Signal parent process (the test process) that this process is ready to be observed by the
     // ptool being tested.


### PR DESCRIPTION
Backport changes in master to 6.0. I plan to enable the `sync-with-master` action so that these PRs will be created automatically in the future, but this particular backport had some conflicts that needed resolving, and it was cleaner to do this one manually. The conflicts were because some previous backports were done via cherry-picks instead of merges.

The result of this change will be that the contents of 6.0/stage will be identical to master.

ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3695/