### PR TITLE
Github action for doing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Check version
+        # Cargo requires that Cargo.toml contain a version, and that version is
+        # used by cargo-deb to build the package. Make sure that the version has
+        # been incremented to match the new tag.
+        run: |
+          gh_tag=$(echo "${{ github.ref }}")
+          version=${gh_tag#refs/tags/v}
+          echo "Working with version $version"
+          grep -q "version = \"$version\"" Cargo.toml || { echo "Version mismatch"; exit 1; }
+          echo "::set-env name=DEB_PKG_NAME::ptools_${version}_amd64.deb"
+      - name: Install cargo-deb
+        run: cargo install cargo-deb --version 1.27.0
+      - name: Build package
+        run: cargo deb
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload debian package
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./target/debian/${{ env.DEB_PKG_NAME }}
+          asset_name: ${{ env.DEB_PKG_NAME }}
+          asset_content_type: application/vnd.debian.binary-package

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "ptools"
 version = "0.1.0"
 authors = ["John Gallagher"]
+license = "Apache-2.0"
+description = "Utilities for inspecting Linux processes"
+readme = "README.md"
 
 [lib]
 name = "ptools"
@@ -41,6 +44,15 @@ nix = "0.12.0"
 libc = "0.2.48"
 
 [package.metadata.deb]
+maintainer = "Delphix Engineering <eng@delphix.com>"
+section = "debug"
+copyright = "2018, 2020 Delphix"
+
+extended-description = """\
+A collection of utilities for inspecting the state of processes, modeled \
+after the tools by the same name which exist on Solaris/Illumos."""
+
+separate-debug-symbols = true
 assets = [
   # List files we want explicitly so that we don't get the binaries intended for
   # testing.


### PR DESCRIPTION
This adds a github action which will create and publish a release when a tag of the proper form (e.g. `v1.2.3`) is pushed. Publishing binaries will make it simpler to use `ptools` outside of the context of the Delphix engine, and this action will make it simple to publish binaries. For now, the only thing uploaded as part of the release is a debian package for amd64, but I plan to add an RPM in the future. Once this PR is merged I'll push a tag for the `v0.1.0` release.

Testing:
- Ran the action in my fork: https://github.com/jgallag88/ptools/runs/969789611?check_suite_focus=true. This created the following release: https://github.com/jgallag88/ptools/releases/tag/v0.1.0.
- Installed the package from the release on an Ubuntu VM and did some cursory testing of the binaries it contained.

Info about the generated package:
```
$ dpkg -I ptools_0.1.0_amd64.deb
 new Debian package, version 2.0.
 size 188574 bytes: control archive=522 bytes.
     401 bytes,    13 lines      control
     257 bytes,     5 lines      md5sums
 Package: ptools
 Version: 0.1.0
 Architecture: amd64
 Section: debug
 Priority: optional
 Standards-Version: 3.9.4
 Maintainer: Delphix Engineering <eng@delphix.com>
 Installed-Size: 1061
 Depends: libc6 (>= 2.27)
 Description: Utilities for inspecting Linux processes
  A collection of utilities for inspecting the state of processes, modeled after
  the tools by the same name which exist on Solaris/Illumos.
```

cc @sebroy @sdimitro @basil