### PR TITLE
Automatically open backport requests

### DIFF
--- a/.github/workflows/sync-with-master.yml
+++ b/.github/workflows/sync-with-master.yml
@@ -1,0 +1,21 @@
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  sync:
+    strategy:
+      matrix:
+        branch:
+          - 6.0/stage
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: delphix/actions/sync-with-master@master
+        with:
+          branch-to-sync: ${{ matrix.branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use the `sync-with-master` action to automatically open backport PRs. I've tested this with my fork to confirm that it works as expected.