### PR TITLE
Fix pfiles on platforms with 32-bit stat.st_ino

### DIFF
--- a/src/ptools.rs
+++ b/src/ptools.rs
@@ -572,7 +572,7 @@ fn print_file(pid: u64, fd: u64, sockets: &HashMap<u64, SockInfo>) {
             // any info for the socket in procfs.
             // TODO make sure we are displaying information that is for the correct namespace
             // TODO handle IPv6
-            if let Some(sock_info) = sockets.get(&stat_info.st_ino) {
+            if let Some(sock_info) = sockets.get(&(stat_info.st_ino as u64)) {
                 print_sock_type(&sock_info.sock_type);
                 print_sock_address(&sock_info);
             } else {


### PR DESCRIPTION
On some platforms, like ARMv7, the struct returned by `stat()` has a 32-bit `st_ino` field. The causes a compilation failure:

    error[E0308]: mismatched types
       --> src/ptools.rs:575:50
        |
    575 |             if let Some(sock_info) = sockets.get(&stat_info.st_ino) {
        |                                                  ^^^^^^^^^^^^^^^^^ expected `u64`, found `u32`
        |
        = note: expected reference `&u64`
                   found reference `&u32`

This adds a cast of the inode to a 64-bit value so that pfiles works even if the inode is smaller. Testing on an ARMv7 system:

    john@arm-test:~/ptools$ ./target/release/pfiles 1051
    1051:   curl http://4.4.8.8
        0: S_IFCHR mode:600 dev:0,6 ino:1026 uid:1000 gid:5 rdev:204,64
           O_RDWR|O_LARGEFILE
           /dev/ttyAMA0
        1: S_IFCHR mode:600 dev:0,6 ino:1026 uid:1000 gid:5 rdev:204,64
           O_RDWR|O_LARGEFILE
           /dev/ttyAMA0
        2: S_IFCHR mode:600 dev:0,6 ino:1026 uid:1000 gid:5 rdev:204,64
           O_RDWR|O_LARGEFILE
           /dev/ttyAMA0
        3: S_IFSOCK mode:777 dev:0,9 ino:19261 uid:1000 gid:1000 size:0
           O_RDWR|O_NDELAY | O_NONBLOCK
             SOCK_STREAM
             sockname: AF_INET 10.0.2.15  port: 51566
             peername: AF_INET 4.4.8.8  port: 80