### PR TITLE
Fix package release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           version=${gh_tag#refs/tags/v}
           echo "Working with version $version"
           grep -q "version = \"$version\"" Cargo.toml || { echo "Version mismatch"; exit 1; }
-          echo "::set-env name=DEB_PKG_NAME::ptools_${version}_amd64.deb"
+          echo "DEB_PKG_NAME=ptools_${version}_amd64.deb" >> $GITHUB_ENV
       - name: Install cargo-deb
         run: cargo install cargo-deb --version 1.27.0
       - name: Build package

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ptools"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["John Gallagher"]
 license = "Apache-2.0"
 description = "Utilities for inspecting Linux processes"


### PR DESCRIPTION
Following the example in https://github.com/delphix/libkdumpfile/pull/18/files, this updates the package release workflow to account for the deprecation of the `::set-env` syntax in github actions. It uses the suggested alternative: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#environment-files

I've tested this by pushing this change to my fork, and then pushing a tag to my fork, and confirming that the workflow ran successfully, creating a new release.

Since, it's been a while since I've done a release and some useful fixes have gone in since then, I've also bumped the version number. After this change lands I'll tag this commit and create a release from it.